### PR TITLE
게시판 API 만들기 - Data Rest 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'  // 미리 만들어진 API 테스트 웹 사이트 제공
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/fastcampus/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.repository;
 
 import com.fastcampus.projectboard2.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/fastcampus/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.repository;
 
 import com.fastcampus.projectboard2.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,4 +25,9 @@ spring:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated  #@RepositoryRestResource 어노테이션이 있는 것만 적용
+
+
 

--- a/src/test/java/com/fastcampus/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/controller/DataRestTest.java
@@ -1,0 +1,75 @@
+package com.fastcampus.controller;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data Rest API 테스트")
+//@WebMvcTest // DataRest는 이걸로 테스트 할 수 없음
+@AutoConfigureMockMvc // McokMvc의 존재를 파악
+@Transactional
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mockMvc;
+
+    public DataRestTest(@Autowired MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+    
+    @Test
+    @DisplayName("API 게시글 리스트 조회")
+    void test1() throws Exception {
+        //given
+        mockMvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json"))); // MediaType 검사에는 HaL json 타입이 없으므로 valueOf로 검사
+    }
+
+    @Test
+    @DisplayName("API 게시글 단건 조회")
+    void test2() throws Exception {
+        //given
+        mockMvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json"))); // MediaType 검사에는 HaL json 타입이 없으므로 valueOf로 검사
+    }
+
+    @Test
+    @DisplayName("API 게시글 댓글 조회")
+    void test3() throws Exception {
+        //given
+        mockMvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json"))); // MediaType 검사에는 HaL json 타입이 없으므로 valueOf로 검사
+    }
+
+    @Test
+    @DisplayName("API 댓글 리스트 조회")
+    void test4() throws Exception {
+        //given
+        mockMvc.perform(get("/api/articleComment"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json"))); // MediaType 검사에는 HaL json 타입이 없으므로 valueOf로 검사
+    }
+
+    @Test
+    @DisplayName("API 게시글 단건 조회")
+    void testName() throws Exception {
+        //given
+        mockMvc.perform(get("/api/articleComment/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json"))); // MediaType 검사에는 HaL json 타입이 없으므로 valueOf로 검사
+    }
+}


### PR DESCRIPTION
게시판, 게시글, 댓글 데이터는 간편하게 Spring Data Rest로 서비스하고, 해당 API들의 존재 여부만 체크할 수 있게 통합테스트 작성